### PR TITLE
Backfill missing lab metadata (9 files)

### DIFF
--- a/Instructions/AZ-120_Lab00_Prerequisites.md
+++ b/Instructions/AZ-120_Lab00_Prerequisites.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: '00 - Lab prerequisites'
-    module: 'Module 00 - Lab prerequisites'
+  title: 00 - Lab prerequisites
+  module: Module 00 - Lab prerequisites
+  description: 'Timeframe: 30 minutes'
+  duration: 30 minutes
+  level: 200
+  islab: true
 ---
 
 # AZ 120: Lab prerequisites

--- a/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
+++ b/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '02a - Implement Linux clustering on Azure VMs'
-    module: 'Module 02 - Explore the foundations of IaaS for SAP on Azure'
+  title: 02a - Implement Linux clustering on Azure VMs
+  module: Module 02 - Explore the foundations of IaaS for SAP on Azure
+  description: 'Estimated Time: 90 minutes'
+  duration: 90 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 120 Module 2: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
+++ b/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '01b - Implement Windows clustering on Azure VMs'
-    module: 'Module 01 - Explore the foundations of IaaS for SAP on Azure'
+  title: 01b - Implement Windows clustering on Azure VMs
+  module: Module 01 - Explore the foundations of IaaS for SAP on Azure
+  description: 'Estimated Time: 120 minutes'
+  duration: 120 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Windows
 ---
 
 # AZ 120 Module 1: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '04a - Implement SAP architecture on Azure VMs running Linux'
-    module: 'Module 04 - Deploy SAP on Azure'
+  title: 04a - Implement SAP architecture on Azure VMs running Linux
+  module: Module 04 - Deploy SAP on Azure
+  description: 'Estimated Time: 100 minutes'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '04b - Implement SAP architecture on Azure VMs running Windows'
-    module: 'Module 04 - Deploy SAP on Azure'
+  title: 04b - Implement SAP architecture on Azure VMs running Windows
+  module: Module 04 - Deploy SAP on Azure
+  description: 'Estimated Time: 150 minutes'
+  duration: 150 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Windows
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab05-ACSS_Deployment.md
+++ b/Instructions/AZ-120_Lab05-ACSS_Deployment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '05 - Automate deployment by using Azure Center for SAP solutions'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 05 - Automate deployment by using Azure Center for SAP solutions
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'Estimated Time: 100 minutes'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 120 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '06a - Overview of prerequisites for deployment of Azure Center for SAP solutions (ACSS)'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06a - Overview of prerequisites for deployment of Azure Center for SAP solutions
+    (ACSS)
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'Estimated Time: 100 minutes'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '06b - Overview of deployment and maintenance of Azure Center for SAP solutions (ACSS)'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06b - Overview of deployment and maintenance of Azure Center for SAP solutions
+    (ACSS)
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'Estimated Time: 100 minutes'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '06c - Overview of deployment Azure Center for SAP solutions'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06c - Overview of deployment Azure Center for SAP solutions
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'Estimated Time: 60 minutes'
+  duration: 60 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 9

- `Instructions/AZ-120_Lab00_Prerequisites.md` (description,duration,level,islab)
- `Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab05-ACSS_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06a-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06b-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06c-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
