### PR TITLE
Backfill missing lab metadata (8 files)

### DIFF
--- a/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
+++ b/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '02a - Implement Linux clustering on Azure VMs'
-    module: 'Module 02 - Explore the foundations of IaaS for SAP on Azure'
+  title: 02a - Implement Linux clustering on Azure VMs
+  module: Module 02 - Explore the foundations of IaaS for SAP on Azure
+  description: In this exercise, you will deploy Azure infrastructure compute components necessary to configure Linux clustering. This will involve creating a pair of Azure VMs running Linux SUSE in the same availability set and provisioning Azure Bastion.
+  duration: 90 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Bastion
 ---
 
 # AZ 120 Module 2: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
+++ b/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
@@ -2,7 +2,7 @@
 lab:
   title: 02a - Implement Linux clustering on Azure VMs
   module: Module 02 - Explore the foundations of IaaS for SAP on Azure
-  description: In this exercise, you will deploy Azure infrastructure compute components necessary to configure Linux clustering. This will involve creating a pair of Azure VMs running Linux SUSE in the same availability set and provisioning Azure Bastion.
+  description: Provision Azure compute resources necessary to support highly available SAP HANA deployments. Configure operating system of Azure VMs running Linux to support a highly available SAP HANA installation. Provision Azure network resources necessary to support highly available SAP HANA deployments.
   duration: 90 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
+++ b/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
@@ -2,7 +2,7 @@
 lab:
   title: 02a - Implement Linux clustering on Azure VMs
   module: Module 02 - Explore the foundations of IaaS for SAP on Azure
-  description: Provision Azure compute resources necessary to support highly available SAP HANA deployments. Configure operating system of Azure VMs running Linux to support a highly available SAP HANA installation. Provision Azure network resources necessary to support highly available SAP HANA deployments.
+  description: Deploy Azure infrastructure compute components necessary to configure Linux clustering. This will involve creating a pair of Azure VMs running Linux SUSE in the same availability set and provisioning Azure Bastion. Configure operating system and storage on Azure VMs running SUSE Linux Enterprise Server to accommodate clustered installations of SAP HANA. Implement Azure Load Balancers to accommodate clustered installations of SAP HANA.
   duration: 90 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
+++ b/Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md
@@ -8,7 +8,7 @@ lab:
   islab: true
   primarytopics:
     - Azure
-    - Azure Bastion
+    - SAP
 ---
 
 # AZ 120 Module 2: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
+++ b/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
@@ -8,10 +8,7 @@ lab:
   islab: true
   primarytopics:
     - Azure
-    - Azure Resource Manager
-    - Windows
-    - Active Directory
-    - Windows Server
+    - SAP
 ---
 
 # AZ 120 Module 1: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
+++ b/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
@@ -2,7 +2,7 @@
 lab:
   title: 01b - Implement Windows clustering on Azure VMs
   module: Module 01 - Explore the foundations of IaaS for SAP on Azure
-  description: In this exercise, you will deploy Azure infrastructure compute components necessary to configure Failover Clustering on Azure VMs running Windows Server 2022. This will involve deploying a pair of Active Directory domain controllers, followed by a pair of Azure VMs running Windows Server 2022. Each pair of the VMs will be placed in separate availability zones within the same virtual network. To automate the deployment of domain controllers, you will use an Azure Resource Manager QuickStart template available from <https://aka.ms/az120-1bdeploy
+  description: Provision Azure compute resources necessary to support highly available SAP NetWeaver deployments. Configure operating system of Azure VMs running Windows Server 2022 Datacenter to support a highly available SAP NetWeaver installation. Provision Azure network resources necessary to support highly available SAP NetWeaver deployments.
   duration: 120 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
+++ b/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
@@ -2,7 +2,7 @@
 lab:
   title: 01b - Implement Windows clustering on Azure VMs
   module: Module 01 - Explore the foundations of IaaS for SAP on Azure
-  description: Provision Azure compute resources necessary to support highly available SAP NetWeaver deployments. Configure operating system of Azure VMs running Windows Server 2022 Datacenter to support a highly available SAP NetWeaver installation. Provision Azure network resources necessary to support highly available SAP NetWeaver deployments.
+  description: Deploy Azure infrastructure compute components necessary to configure Failover Clustering on Azure VMs running Windows Server 2022. Join Windows Server 2022 Datacenter VMs to the Active Directory domain. Implement Azure Load Balancers to accommodate clustered installations of SAP NetWeaver.
   duration: 120 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
+++ b/Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: '01b - Implement Windows clustering on Azure VMs'
-    module: 'Module 01 - Explore the foundations of IaaS for SAP on Azure'
+  title: 01b - Implement Windows clustering on Azure VMs
+  module: Module 01 - Explore the foundations of IaaS for SAP on Azure
+  description: In this exercise, you will deploy Azure infrastructure compute components necessary to configure Failover Clustering on Azure VMs running Windows Server 2022. This will involve deploying a pair of Active Directory domain controllers, followed by a pair of Azure VMs running Windows Server 2022. Each pair of the VMs will be placed in separate availability zones within the same virtual network. To automate the deployment of domain controllers, you will use an Azure Resource Manager QuickStart template available from <https://aka.ms/az120-1bdeploy
+  duration: 120 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Resource Manager
+    - Windows
+    - Active Directory
+    - Windows Server
 ---
 
 # AZ 120 Module 1: Explore the foundations of IaaS for SAP on Azure

--- a/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
@@ -3,7 +3,7 @@ lab:
   title: 04a - Implement SAP architecture on Azure VMs running Linux
   module: Module 04 - Deploy SAP on Azure
   description: Deploy Azure infrastructure compute components, Azure VMs running Linux SUSE in the same availability set, necessary to configure Linux clustering. Configure Azure VMs running SUSE Linux Enterprise Server to accommodate a highly available SAP NetWeaver deployment. Configure clustering on Azure VMs running Linux to support a highly available SAP NetWeaver deployment.
-  duration: 100 minutes
+  duration: 90 minutes
   level: 500
   islab: true
   primarytopics:

--- a/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
@@ -8,6 +8,7 @@ lab:
   islab: true
   primarytopics:
     - Azure
+    - SAP
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '04a - Implement SAP architecture on Azure VMs running Linux'
-    module: 'Module 04 - Deploy SAP on Azure'
+  title: 04a - Implement SAP architecture on Azure VMs running Linux
+  module: Module 04 - Deploy SAP on Azure
+  description: In this exercise, you will configure clustering on Azure VMs running Linux to support a highly available SAP NetWeaver deployment.
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md
@@ -2,7 +2,7 @@
 lab:
   title: 04a - Implement SAP architecture on Azure VMs running Linux
   module: Module 04 - Deploy SAP on Azure
-  description: In this exercise, you will configure clustering on Azure VMs running Linux to support a highly available SAP NetWeaver deployment.
+  description: Deploy Azure infrastructure compute components, Azure VMs running Linux SUSE in the same availability set, necessary to configure Linux clustering. Configure Azure VMs running SUSE Linux Enterprise Server to accommodate a highly available SAP NetWeaver deployment. Configure clustering on Azure VMs running Linux to support a highly available SAP NetWeaver deployment.
   duration: 100 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: '04b - Implement SAP architecture on Azure VMs running Windows'
-    module: 'Module 04 - Deploy SAP on Azure'
+  title: 04b - Implement SAP architecture on Azure VMs running Windows
+  module: Module 04 - Deploy SAP on Azure
+  description: In this exercise, you will configure operating system of Azure VMs running Windows Server to accommodate a highly available SAP NetWeaver deployment.
+  duration: 150 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Windows
+    - Windows Server
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
@@ -8,8 +8,7 @@ lab:
   islab: true
   primarytopics:
     - Azure
-    - Windows
-    - Windows Server
+    - SAP
 ---
 
 # AZ 120 Module 4: Deploy SAP on Azure

--- a/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
+++ b/Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md
@@ -2,7 +2,7 @@
 lab:
   title: 04b - Implement SAP architecture on Azure VMs running Windows
   module: Module 04 - Deploy SAP on Azure
-  description: In this exercise, you will configure operating system of Azure VMs running Windows Server to accommodate a highly available SAP NetWeaver deployment.
+  description: Deploy Azure infrastructure compute components necessary to configure Windows clustering. This will involve creating a pair of Azure VMs running Windows Server 2016 in the same availability set. configure operating system of Azure VMs running Windows Server to accommodate a highly available SAP NetWeaver deployment. 
   duration: 150 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab05-ACSS_Deployment.md
+++ b/Instructions/AZ-120_Lab05-ACSS_Deployment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '05 - Automate deployment by using Azure Center for SAP solutions'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 05 - Automate deployment by using Azure Center for SAP solutions
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'In this exercise, you will implement prerequisites for deploying SAP workloads in Azure by using Azure Center for SAP solutions. This will include the following tasks:'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # AZ 120 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab05-ACSS_Deployment.md
+++ b/Instructions/AZ-120_Lab05-ACSS_Deployment.md
@@ -2,12 +2,13 @@
 lab:
   title: 05 - Automate deployment by using Azure Center for SAP solutions
   module: Design and implement an infrastructure to support SAP workloads on Azure
-  description: 'In this exercise, you will implement prerequisites for deploying SAP workloads in Azure by using Azure Center for SAP solutions. This will include the following tasks:'
+  description: 'In this exercise, you will deploy SAP workloads in Azure by using Azure Center for SAP solutions.'
   duration: 100 minutes
   level: 500
   islab: true
   primarytopics:
     - Azure
+    - SAP
 ---
 
 # AZ 120 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab05-ACSS_Deployment.md
+++ b/Instructions/AZ-120_Lab05-ACSS_Deployment.md
@@ -2,7 +2,7 @@
 lab:
   title: 05 - Automate deployment by using Azure Center for SAP solutions
   module: Design and implement an infrastructure to support SAP workloads on Azure
-  description: 'In this exercise, you will deploy SAP workloads in Azure by using Azure Center for SAP solutions.'
+  description: Implement prerequisites for deploying SAP workloads in Azure by using Azure Center for SAP solutions. Use Azure Center for SAP solutions to deploy the infrastructure that will host SAP workloads into an Azure subscription. Following the successful deployment, you can either proceed with installing SAP software by using Azure Center for SAP solutions.
   duration: 100 minutes
   level: 500
   islab: true

--- a/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
@@ -2,12 +2,13 @@
 lab:
   title: 06a - Overview of prerequisites for deployment of Azure Center for SAP solutions (ACSS)
   module: Design and implement an infrastructure to support SAP workloads on Azure
-  description: 'In this exercise, you review and implement prerequisites for deploying SAP workloads in Azure by using Azure Center for SAP solutions. This includes the following activities:'
+  description: 'In this exercise, you deploy secure SAP workloads in Azure by using Azure Center for SAP solutions.'
   duration: 100 minutes
   level: 500
   islab: true
   primarytopics:
     - Azure
+    - SAP
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06a-ACSS_One_Day.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '06a - Overview of prerequisites for deployment of Azure Center for SAP solutions (ACSS)'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06a - Overview of prerequisites for deployment of Azure Center for SAP solutions (ACSS)
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'In this exercise, you review and implement prerequisites for deploying SAP workloads in Azure by using Azure Center for SAP solutions. This includes the following activities:'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
@@ -8,6 +8,7 @@ lab:
   islab: true
   primarytopics:
     - Azure
+    - SAP
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06b-ACSS_One_Day.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '06b - Overview of deployment and maintenance of Azure Center for SAP solutions (ACSS)'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06b - Overview of deployment and maintenance of Azure Center for SAP solutions (ACSS)
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'In this exercise, you perform deployment of Azure Center for SAP solutions. This includes the following activity:'
+  duration: 100 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '06c - Overview of deployment Azure Center for SAP solutions'
-    module: 'Design and implement an infrastructure to support SAP workloads on Azure'
+  title: 06c - Overview of deployment Azure Center for SAP solutions
+  module: Design and implement an infrastructure to support SAP workloads on Azure
+  description: 'In this exercise, you perform deployment of Azure Center for SAP solutions. This includes the following activity:'
+  duration: 60 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure

--- a/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
+++ b/Instructions/AZ-120_Lab06c-ACSS_One_Day.md
@@ -2,12 +2,13 @@
 lab:
   title: 06c - Overview of deployment Azure Center for SAP solutions
   module: Design and implement an infrastructure to support SAP workloads on Azure
-  description: 'In this exercise, you perform deployment of Azure Center for SAP solutions. This includes the following activity:'
+  description: In this exercise, you perform deployment of Azure Center for SAP solutions. 
   duration: 60 minutes
   level: 500
   islab: true
   primarytopics:
     - Azure
+    - SAP
 ---
 
 # AZ 1006 Module: Design and implement an infrastructure to support SAP workloads on Azure


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 8

- `Instructions/AZ-120_Lab01a-Azure_VM_Linux_Clustering.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab01b-Azure_VM_Windows_Clustering.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab03a-HANA_HA_Infrastructure_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab03b-SQL_HA_Infrastructure_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab05-ACSS_Deployment.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06a-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06b-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
- `Instructions/AZ-120_Lab06c-ACSS_One_Day.md` (description,duration,level,islab,primarytopics)
